### PR TITLE
build: support cmake default dir setting with ruby 3

### DIFF
--- a/lib/inchi-gem.rb
+++ b/lib/inchi-gem.rb
@@ -1,2 +1,8 @@
-require_relative '../ext/inchi-gem/inchi'
+# frozen_string_literal: true
+
+begin
+  require_relative '../ext/inchi-gem/inchi'
+rescue LoadError
+  require 'inchi'
+end
 require 'inchi-gem/version'


### PR DESCRIPTION
Ruby 2.7 uses simple make "DESTDIR=" install.

Ruby 3.x adds explicit DESTDIR, sitearchdir, and sitelibdir parameters to stage compiled extensions.